### PR TITLE
fix(build): add sourcemaps to dev build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -56,7 +56,12 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "frontend:build"
+            "browserTarget": "frontend:build",
+            "sourceMap": {
+              "scripts": true,
+              "styles": true,
+              "vendor": true
+            }
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
The previous configuration disabled sourcemaps, so debugging was impossible.

fix #7